### PR TITLE
[FIX] of the issue scikit-learn#17394 and scikit-learn#18065 (problem…

### DIFF
--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -354,6 +354,7 @@ class GaussianProcessRegressor(MultiOutputMixin,
                 # undo normalisation
                 if (self._y_train_std.ndim==0):   # for single-target data
                   y_cov = y_cov * self._y_train_std**2  
+                  
                 elif (self._y_train_std.ndim==1):   # for multitarget data
                   y_cov_temp = y_cov.reshape((y_cov.shape[0], y_cov.shape[1], 1))
                   y_cov = np.zeros((y_cov.shape[0], y_cov.shape[1], self._y_train_std.shape[0]))


### PR DESCRIPTION
… with GPR predictions on multitarget data)

Initially, when a multitarget data was given, the _gpr.py was not able to undo the normalisation of y_cov and y_var in the predict() function (lines 355 and 381). The problem was the fact that the code was trying to multiply two horizontal vectors in both cases and returned error "ValueError: operands could not be broadcast together with shapes (a,) (b,)" (e.g. number of samples 'a' = 4, number of target components 'b' = 3). I solved this by reshaping the y_var vector and rows of y_cov into vertical form before multiplication with the train std vector. As a result, we obtain y_std of form (n_samples, n_output_dims) and y_cov of form (n_samples, n_samples, n_output_dims). When targets are single values (dim = 0) the undo normalisation is performed as usual.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
